### PR TITLE
fix: use TARGET_HOME variable instead of hardcoded ~/.zshrc path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -610,7 +610,7 @@ log "INFO" "Working directory: ${DOTFILEDIR}"
 
 log "INFO" "Copying configuration files to home directory..."
 
-sed -i 's/^ZSH_THEME="[^"]*"/ZSH_THEME="agnoster"/' ~/.zshrc
+sed -i 's/^ZSH_THEME="[^"]*"/ZSH_THEME="agnoster"/' "$TARGET_HOME/.zshrc"
 
 # List of configuration files to copy
 declare -a config_files=(


### PR DESCRIPTION
## Summary
• Fixed hardcoded `~/.zshrc` path on line 613 to use `$TARGET_HOME/.zshrc`
• Ensures proper functionality when running as root for another user in cloud-init scenarios
• Addresses critical bug that would cause installation failures in automated deployments

## Test plan
- [x] Verified the fix changes the correct line
- [ ] Test manual installation as regular user
- [ ] Test cloud-init installation as root with --user flag

🤖 Generated with [Claude Code](https://claude.ai/code)