### PR TITLE
fix: add macOS compatibility for sed -i commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -586,7 +586,7 @@ setup_shell_config() {
             # Create a backup
             cp "$shellrc" "$shellrc.backup.$(date +%Y%m%d_%H%M%S)"
             # Replace hardcoded path with $HOME version
-            sed -i "s|export PATH=\$PATH:[^:]*${TARGET_USER}[^:]*\.local/bin|${home_localbin_export}|g" "$shellrc"
+            sed -i '' "s|export PATH=\$PATH:[^:]*${TARGET_USER}[^:]*\.local/bin|${home_localbin_export}|g" "$shellrc"
             set_ownership "$shellrc"
         fi
     fi
@@ -637,7 +637,7 @@ log "INFO" "Copying configuration files to home directory..."
 
 # Update ZSH theme if .zshrc exists
 if [[ -f "$TARGET_HOME/.zshrc" ]]; then
-    sed -i 's/^ZSH_THEME="[^"]*"/ZSH_THEME="agnoster"/' "$TARGET_HOME/.zshrc"
+    sed -i '' 's/^ZSH_THEME="[^"]*"/ZSH_THEME="agnoster"/' "$TARGET_HOME/.zshrc"
 fi
 
 # List of configuration files to copy


### PR DESCRIPTION
## Summary
- Add empty string backup suffix to `sed -i` commands in install.sh (lines 589 and 640)
- Fixes compatibility with macOS BSD sed, which requires a backup extension argument
- Resolves installation failure on macOS systems

## Test plan
- [x] Tested installation script on macOS - runs successfully without errors
- [x] Verified both sed commands now work correctly on macOS

🤖 Generated with [Claude Code](https://claude.ai/code)