### PR TITLE
Add Claude MCP configuration support to install script

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "Perplexity": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "perplexity-mcp"
+      ],
+      "tools": ["*"],
+      "env": {
+        "PERPLEXITY_API_KEY": "${input:perplexity-api-key}",
+        "PERPLEXITY_MODEL": "sonar"
+      }
+    }
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -680,6 +680,16 @@ else
     log "WARN" "$claude_settings_src not found, skipping Claude settings copy."
 fi
 
+# Copy mcp.json if present
+claude_mcp_src="./.claude/mcp.json"
+claude_mcp_dest="$claude_dir/mcp.json"
+if [[ -f "$claude_mcp_src" ]]; then
+    safe_copy_user "$claude_mcp_src" "$claude_mcp_dest"
+    log "INFO" "Copied $claude_mcp_src to $claude_mcp_dest."
+else
+    log "WARN" "$claude_mcp_src not found, skipping Claude MCP config copy."
+fi
+
 log "INFO" "Setting up VSCode configuration..."
 vscode_dir="$TARGET_HOME/.vscode"
 


### PR DESCRIPTION
## Summary
- Add installation logic for `.claude/mcp.json` file in install.sh script
- Support Claude's Model Context Protocol configuration alongside existing settings.json handling
- Follows same pattern as existing Claude config installation with proper error handling

## Test plan
- [ ] Verify install script copies .claude/mcp.json to ~/.claude/mcp.json when present
- [ ] Verify install script logs appropriate warning when .claude/mcp.json is not found
- [ ] Confirm no regression in existing Claude settings.json installation

🤖 Generated with [Claude Code](https://claude.ai/code)