### PR TITLE
feat: enhance Claude binary detection and add Microsoft MCP servers

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -25,6 +25,25 @@
         "--rm",
         "hashicorp/terraform-mcp-server"
       ]
+    },
+    "microsoft-learn": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@microsoft/learn-mcp"
+      ],
+      "tools": ["*"]
+    },
+    "microsoft-azure": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@microsoft/azure-mcp"
+      ],
+      "tools": ["*"],
+      "env": {
+        "AZURE_AUTH_METHOD": "cli"
+      }
     }
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -270,7 +270,18 @@ find_claude_binary() {
     
     # First check common direct paths
     for path in "${possible_paths[@]}"; do
-        if [[ -f "$path" && -x "$path" ]]; then
+        if [[ -L "$path" ]]; then
+            # Handle symlinks - check if target exists
+            if [[ -f "$path" && -x "$path" ]]; then
+                claude_path="$path"
+                log "INFO" "Found Claude binary at: $claude_path (symlink)"
+                echo "$claude_path"
+                return 0
+            else
+                log "WARN" "Found broken Claude symlink at: $path - removing"
+                rm -f "$path" 2>/dev/null || true
+            fi
+        elif [[ -f "$path" && -x "$path" ]]; then
             claude_path="$path"
             log "INFO" "Found Claude binary at: $claude_path"
             echo "$claude_path"


### PR DESCRIPTION
## Summary
- Improve Claude binary detection to handle broken symlinks gracefully
- Add automatic cleanup of broken symlinks during installation to prevent startup warnings
- Add Microsoft Learn MCP server integration for enhanced documentation capabilities
- Add Microsoft Azure MCP server with CLI authentication for cloud operations

## Changes Made
### Claude Binary Detection Enhancement (`install.sh`)
- Enhanced `find_claude_binary()` function to detect and handle broken symlinks
- Added automatic removal of broken symlinks with proper logging
- Prevents Claude startup warning about invalid `/opt/homebrew/bin/claude` symlink
- Maintains existing functionality while improving robustness

### MCP Server Integration (`.claude/mcp.json`)
- Added Microsoft Learn MCP server (`@microsoft/learn-mcp`)
- Added Microsoft Azure MCP server (`@microsoft/azure-mcp`) with CLI authentication
- Expanded Claude Code capabilities with Microsoft ecosystem integration

## Test Plan
- [x] Verify enhanced symlink detection works correctly
- [x] Confirm broken symlink cleanup functionality
- [x] Test MCP server configurations load properly
- [x] Validate no regression in existing Claude binary detection

🤖 Generated with [Claude Code](https://claude.ai/code)