### PR TITLE
chore: remove context7 MCP server configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-  "mcpServers": {
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ],
-      "tools": ["*"]
-    }
-  },
   "permissions": {
     "allow": [
       "Bash",


### PR DESCRIPTION
## Summary
- Removed the context7 MCP server configuration from Claude settings
- The server is no longer needed in the current setup

## Changes
- Deleted context7 MCP server configuration block from `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.ai/code)