### PR TITLE
fix(install): ensure parent directories exist before creating nested paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1311,12 +1311,17 @@ fi
 #cp .continue/config.json ~/.continue
 
 log "INFO" "Setting up tmux plugins..."
+safe_mkdir_user "$TARGET_HOME/.tmux"
 safe_mkdir_user "$TARGET_HOME/.tmux/plugins"
 
 git_clone_or_update_user "https://github.com/tmux-plugins/tpm" "$TARGET_HOME/.tmux/plugins/tpm"
 log "INFO" "Tmux plugins set up successfully"
 
 log "INFO" "Setting up Vim plugins and themes..."
+safe_mkdir_user "$TARGET_HOME/.vim"
+safe_mkdir_user "$TARGET_HOME/.vim/pack"
+safe_mkdir_user "$TARGET_HOME/.vim/pack/plugin"
+safe_mkdir_user "$TARGET_HOME/.vim/pack/themes"
 safe_mkdir_user "$TARGET_HOME/.vim/pack/plugin/start"
 safe_mkdir_user "$TARGET_HOME/.vim/pack/themes/start"
 
@@ -1464,6 +1469,7 @@ log "INFO" "Zsh plugins configured successfully"
 
 log "INFO" "Setting up Oh My Posh prompt theme..."
 safe_mkdir_user "$TARGET_HOME/.local/bin"
+safe_mkdir_user "$TARGET_HOME/.oh-my-posh"
 safe_mkdir_user "$TARGET_HOME/.oh-my-posh/themes"
 
 log "INFO" "Installing Oh My Posh..."


### PR DESCRIPTION
## Summary
Fix logical flaws in directory creation where nested directories were being created without ensuring parent directories exist first. This prevents potential race conditions and permission issues during installation.

## Changes
- Add explicit ~/.tmux directory creation before plugins directory  
- Add intermediate directory creation for Vim (.vim, .vim/pack, etc.)
- Add explicit ~/.oh-my-posh directory creation before themes directory

## Test plan
- [ ] Verify installation runs without directory creation errors
- [ ] Test on fresh system without existing directories  
- [ ] Confirm proper ownership and permissions are maintained

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>