### PR TITLE
Fix HOME directory detection when running as root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,12 @@ setup_target_user() {
     if [[ -n "${DOTFILES_USER:-}" ]]; then
         TARGET_USER="$DOTFILES_USER"
     elif [[ -z "$TARGET_USER" ]]; then
-        if [[ "$CLOUD_INIT_MODE" == "true" && "$EUID" -eq 0 ]]; then
+        # When running as root without cloud-init mode or explicit user specification,
+        # install for root itself rather than trying to find another user
+        if [[ "$EUID" -eq 0 && "$CLOUD_INIT_MODE" == "false" ]]; then
+            TARGET_USER="root"
+            log "INFO" "Running as root without --user or --cloud-init, installing for root user"
+        elif [[ "$CLOUD_INIT_MODE" == "true" && "$EUID" -eq 0 ]]; then
             # In cloud-init as root, try to detect the main user
             if [[ -n "${SUDO_USER:-}" ]]; then
                 TARGET_USER="$SUDO_USER"


### PR DESCRIPTION
## Summary
- Fixed incorrect HOME directory detection when install.sh is run as root
- Script now correctly installs to /root instead of /home/ubuntu when run as root user

## Problem
When running `./install.sh` as root without the `--cloud-init` or `--user` flags, the script was incorrectly detecting the first non-system user (e.g., ubuntu with UID 1000) and installing dotfiles to their home directory instead of `/root`.

## Solution
Added explicit logic to detect when the script is run as root without cloud-init mode or user specification, and sets `TARGET_USER="root"` appropriately. This ensures dotfiles are installed to the correct location based on the actual user running the script.

## Test Plan
- [x] Run `sudo ./install.sh` and verify it installs to `/root`
- [x] Run `./install.sh --cloud-init --user ubuntu` and verify it still works for cloud-init scenarios
- [x] Run `./install.sh` as a regular user and verify it installs to that user's home

🤖 Generated with [Claude Code](https://claude.ai/code)