### PR TITLE
Fix Oh My Zsh core file detection logic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2211,7 +2211,7 @@ fi
 log "INFO" "Setting up Zsh and Oh My Zsh..."
 oh_my_zsh_dir="$TARGET_HOME/.oh-my-zsh"
 
-if [[ ! -d "$oh_my_zsh_dir" ]]; then
+if [[ ! -d "$oh_my_zsh_dir" ]] || [[ ! -f "$oh_my_zsh_dir/oh-my-zsh.sh" ]]; then
     log "INFO" "Installing Oh My Zsh..."
     
     # Enhanced Oh My Zsh installation with better error handling
@@ -2245,7 +2245,7 @@ if [[ ! -d "$oh_my_zsh_dir" ]]; then
         log "ERROR" "Oh My Zsh installation failed - directory does not exist"
     fi
 else
-    log "INFO" "Oh My Zsh already installed"
+    log "INFO" "Oh My Zsh directory exists with core files"
     
     # Verify existing installation
     if [[ -f "$oh_my_zsh_dir/oh-my-zsh.sh" ]]; then


### PR DESCRIPTION
## Summary
- Changes installation check from directory-only to include core file verification
- Now checks for both directory existence AND oh-my-zsh.sh core file presence
- Prevents false 'already installed' detection when only empty directory structure exists

## Root Cause
The current logic only checks if  directory exists, but the  function creates this directory early in the installation process before Oh My Zsh is actually installed. This causes the installation to be skipped, leaving only an empty directory structure without the essential  core file.

## Technical Changes
**Before:**
```bash
if [[ \! -d "$oh_my_zsh_dir" ]]; then
```

**After:**
```bash
if [[ \! -d "$oh_my_zsh_dir" ]] || [[ \! -f "$oh_my_zsh_dir/oh-my-zsh.sh" ]]; then
```

## Test Plan
- [x] Verified the logic correctly identifies when core files are missing
- [x] Updated log messages to reflect improved detection logic
- [x] Maintains backward compatibility with existing installations

Fixes #319

🤖 Generated with [Claude Code](https://claude.ai/code)