### PR TITLE
Fix: Remove invalid 'local' keyword used outside function context

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2503,7 +2503,7 @@ if [[ -f "$oh_my_posh_bin" ]]; then
         if run_as_user_with_home "'$oh_my_posh_bin' font install Meslo" 2>/dev/null; then
             log "INFO" "Meslo font installation completed successfully"
         else
-            local exit_code=$?
+            exit_code=$?
             log "DEBUG" "oh-my-posh font install returned exit code $exit_code"
             
             # Verify if fonts were actually installed despite the error


### PR DESCRIPTION
## Summary
- Fixed bash syntax error in install.sh at line 2506
- Removed 'local' keyword that was being used outside of a function
- This error was causing cloud-init scripts to fail during CLOUDSHELL VM provisioning

## Problem
The script had `local exit_code=$?` at the top level of the script (not inside a function), which caused the error:
```
install.sh: line 2506: local: can only be used in a function
```

## Solution
Simply removed the 'local' keyword while preserving the variable assignment functionality.

## Testing
- [x] Verified syntax with `bash -n install.sh`
- [x] Confirmed the fix preserves the original functionality
- [x] Error was observed in cloud-init logs and is now resolved

🤖 Generated with [Claude Code](https://claude.ai/code)